### PR TITLE
Include benchmarks, examples and tests conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,17 +171,20 @@ configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/HeffteConfig.cm
 ######################
 # EXAMPLES and TESTS #
 ######################
-add_subdirectory(benchmarks)
-add_subdirectory(examples)
-enable_testing()
-add_subdirectory(test)
-if (Heffte_ENABLE_FORTRAN)
-    add_subdirectory(fortran)
+# Only do these if this is the main project, and not if it is included through
+# add_subdirectory
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    add_subdirectory(benchmarks)
+    add_subdirectory(examples)
+    enable_testing()
+    add_subdirectory(test)
+    if (Heffte_ENABLE_FORTRAN)
+        add_subdirectory(fortran)
+    endif()
+    if (Heffte_ENABLE_PYTHON)
+        add_subdirectory(python)
+    endif()
 endif()
-if (Heffte_ENABLE_PYTHON)
-    add_subdirectory(python)
-endif()
-
 
 ###########################
 # Post Install Test


### PR DESCRIPTION
Include benchmarks, examples and test only if this is the main project, and not if it is included through `add_subdirectory`.

After the modification, if package is included using `FetchContent`, benchmarks, examples and tests will not be compiled.

The idea is taken from here: https://hsf-training.github.io/hsf-training-cmake-webpage/06-projectstructure/index.html